### PR TITLE
add knn

### DIFF
--- a/Formula/opensearch-knn.rb
+++ b/Formula/opensearch-knn.rb
@@ -1,0 +1,54 @@
+class OpensearchKnn < Formula
+  desc "K-nearest neighbors (k-NN) plugin for OpenSearch"
+  homepage "https://github.com/opensearch-project/k-NN"
+  url "https://github.com/opensearch-project/k-NN/archive/refs/tags/3.2.0.0.tar.gz"
+  sha256 "c0b3f7883953c8a576746f0ad0727b77448a046abe6f5e95bd04d0279839ef44"
+  license "Apache-2.0"
+
+  depends_on "gradle@8" => :build
+  depends_on "openjdk@21" => :build
+  depends_on "opensearch"
+
+  def install
+    ENV["JAVA_HOME"] = Formula["openjdk@21"].opt_prefix
+    
+    system "gradle", "bundlePlugin", "-x", "test", 
+           "-PopensearchVersion=3.2.0"
+    
+    plugin_file = Dir["plugin/build/distributions/opensearch-knn-*.zip"].first
+    raise "Plugin zip file not found" unless plugin_file
+    libexec.install plugin_file => "plugin.zip"
+  end
+
+  def post_install
+    opensearch = Formula["opensearch"]
+    
+    # Check if plugin is already installed
+    plugin_list = `#{opensearch.bin}/opensearch-plugin list 2>/dev/null`.strip
+    
+    if plugin_list.include?("opensearch-knn")
+      puts "==> opensearch-knn plugin already installed, updating..."
+      system opensearch.bin/"opensearch-plugin", "remove", "opensearch-knn", :out => File::NULL, :err => File::NULL
+    end
+    
+    system opensearch.bin/"opensearch-plugin", "install", "--batch",
+           "file://#{libexec}/plugin.zip"
+  end
+
+  def caveats
+    <<~EOS
+      k-NN plugin has been installed.
+      
+      To use k-NN functionality, you may need to restart OpenSearch:
+      brew services restart opensearch
+      
+      Verify plugin installation with: opensearch-plugin list
+    EOS
+  end
+
+  test do
+    opensearch = Formula["opensearch"]
+    output = shell_output("#{opensearch.bin}/opensearch-plugin list")
+    assert_match "opensearch-knn", output
+  end
+end

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ brew install opensearch-ml-models   # Installs and configures ML models
 - **Memory:** Automatically configures 4GB JVM heap
 - **Dependencies:** Requires opensearch-ml-commons
 
+### `opensearch-knn`
+- **Version:** 3.2.0.0
+- **Description:** K-nearest neighbors (k-NN) plugin for OpenSearch
+- **Installation:** `brew install opensearch-knn`
+
 ## Intel Mac Compatibility
 
 This tap includes critical patches for ML Commons on Intel Macs to resolve PyTorch compatibility issues:


### PR DESCRIPTION
This pull request introduces a new Homebrew formula for the OpenSearch k-NN plugin, allowing users to easily install and manage the k-nearest neighbors plugin for OpenSearch via Homebrew. Documentation is also updated to reflect the new package and its usage.

**New Formula Addition:**

* Added `Formula/opensearch-knn.rb` to provide a Homebrew formula for installing the OpenSearch k-NN plugin, including build steps, installation, post-install plugin management, caveats, and a test block.

**Documentation Update:**

* Updated `README.md` to document the new `opensearch-knn` formula, including version, description, and installation instructions.